### PR TITLE
Remove custom config file source for Hyprland

### DIFF
--- a/modules/hyprland.nix
+++ b/modules/hyprland.nix
@@ -88,7 +88,6 @@ in
 
     xdg.configFile."hypr/hyprlock".source =                 "${illogical-impulse-dotfiles}/.config/hypr/hyprlock";
     xdg.configFile."hypr/shaders".source =                  "${illogical-impulse-dotfiles}/.config/hypr/shaders";
-    xdg.configFile."hypr/custom".source =                   "${illogical-impulse-dotfiles}/.config/hypr/custom";
 
   };
 }


### PR DESCRIPTION
let user to customize their build without rebuild the entire nixos